### PR TITLE
Fixed _mmap() return value.

### DIFF
--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -92,8 +92,15 @@ int _mmap(inject_ctx *ctx, void *addr, size_t len, int prot, int flags, int fd, 
 	if (waitpid(ctx->pid, &i, 0) < 0)
 		perror("waitpid");
 
+	// Get registers after the syscall
+	if (ptrace(PTRACE_GETREGS, ctx->pid, NULL, regs) < 0) {
+		perror("ptrace");
+		exit(-1);
+	}
+
 	ptrace(PTRACE_SETREGS, ctx->pid, NULL, &regs_bak);
 
+	// Return value of mmap()
 	maddr = regs->rax;
 
 	free(regs);


### PR DESCRIPTION
BUG: _mmap() always returns 0x9 because the registers aren't reloaded after the system call.
FIX: call ptrace with PTRACE_GETREGS before restoring the original registers.
