### PR TITLE
Added alternative privsep load search for movs.

### DIFF
--- a/include/elflib.h
+++ b/include/elflib.h
@@ -6,6 +6,6 @@
 
 void _peek_file(FILE *f, unsigned long addr, void *ptr, int len);
 addr_t resolve_symbol(u8 *tab, int tab_size, char *str, char *sym);
-int get_section(char *fn, char *sect, unsigned char **ret);
+int get_section(char *fn, char *sect, unsigned char **ret, u64 *);
 
 #endif

--- a/include/sig.h
+++ b/include/sig.h
@@ -4,6 +4,9 @@
 #define LEA_RDI 0x3d
 #define LEA_RAX 0x05
 
+#define LOAD_LEA 0x8d
+#define LOAD_MOV 0x8b
+
 typedef struct {
 	u64 placeholder;
 	char *name;
@@ -16,7 +19,7 @@ u64 find_sig_mem(inject_ctx *ctx, u8 *sig, int siglen, int perm_mask);
 u64 find_call(inject_ctx *ctx, u64 addr);
 
 u64 lea_by_debugstr(inject_ctx *ctx, u8 lea_reg, char *str);
-u64 find_prev_lea(inject_ctx *ctx, u8 lea_reg, u64 start_addr, u64 lea_addr);
+u64 find_prev_load(inject_ctx *ctx, u8 load_ins, u8 lea_reg, u64 start_addr, u64 lea_addr);
 u64 find_next_opcode(inject_ctx *ctx, u64 start_addr, u8 *sig, u8 siglen);
 u64 sub_by_debugstr(inject_ctx *ctx, char *str);
 u64 resolve_call_insn(inject_ctx *ctx, u64 call_insn_addr);

--- a/src/elflib.c
+++ b/src/elflib.c
@@ -7,7 +7,7 @@
 #include <inject.h>
 #include <elflib.h>
 
-int get_section(char *fn, char *sect, unsigned char **ret) {
+int get_section(char *fn, char *sect, unsigned char **ret, u64 *sect_base) {
 	Elf64_Ehdr	*ehdr = malloc(sizeof(Elf64_Ehdr));
 	Elf64_Shdr	*shdr = malloc(sizeof(Elf64_Shdr));
 	unsigned char *str;
@@ -27,6 +27,7 @@ int get_section(char *fn, char *sect, unsigned char **ret) {
 		_peek_file(f, ehdr->e_shoff + (i * sizeof(Elf64_Shdr)), shdr, sizeof(Elf64_Shdr));
 		if (strcmp((char*)str+shdr->sh_name, sect) == 0) {
 			*ret = malloc(shdr->sh_size);
+			*sect_base = shdr->sh_addr;
 			_peek_file(f, shdr->sh_offset, *ret, shdr->sh_size);
 			break;
 		}

--- a/src/sig.c
+++ b/src/sig.c
@@ -97,12 +97,14 @@ u64 lea_by_debugstr(inject_ctx *ctx, u8 lea_reg, char *str) {
 	return lea_addr;
 }
 
-u64 find_prev_lea(inject_ctx *ctx, u8 lea_reg, u64 start_addr, u64 lea_addr) {
+u64 find_prev_load(inject_ctx *ctx, u8 load_ins, u8 lea_reg, 
+				  u64 start_addr, u64 lea_addr) {
 	int i, j;
 	mem_mapping *mapping;
-	char leabuf[]="\x48\x8d\x00\x00\x00\x00\x00";
+	char leabuf[]="\x48\x00\x00\x00\x00\x00\x00";
 	int *rptr = (int*)&leabuf[3];
 
+	leabuf[1] = load_ins;
 	leabuf[2] = lea_reg;
 
 	for(i = 0; i < ctx->num_maps; i++) {


### PR DESCRIPTION
Sometimes the lea use_privsep instruction is compiled as a mov use_privsep_ptr; mov eax, [rax]
This is a pointer in the .got. This patch tries to first find the direct lea instruction, and only if that cannot be found searches the got for this pointer and then continues to search for a similar mov instruction.
